### PR TITLE
Fix token redaction

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
-  - repo: https://github.com/dirien/pre-commit-hooks/releases
+  - repo: https://github.com/dirien/pre-commit-hooks
     rev: v0.1.0 # Check for the latest version: https://github.com/dirien/pre-commit-hooks/releases
     hooks:
       - id: golangci-lint

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -66,7 +66,7 @@ tasks:
   start-influx:
     desc: Start InfluxDB
     cmds:
-      - ./scripts/setup-influxdb.sh
+      - ./scripts/setup_influxdb.sh
     status:
       - while ! $(curl -sS 'http://localhost:8086/ready' | grep -q ready); do echo 'Waiting for influx...'; sleep 1; done
   stop-influx:

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/janrupf/terraform-provider-influxdb-v2
+module github.com/optile/terraform-provider-influxdb-v2
 
 go 1.19
 

--- a/influxdbv2/data_ready.go
+++ b/influxdbv2/data_ready.go
@@ -3,8 +3,9 @@ package influxdbv2
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	influxdb2 "github.com/influxdata/influxdb-client-go/v2"

--- a/influxdbv2/provider.go
+++ b/influxdbv2/provider.go
@@ -3,6 +3,7 @@ package influxdbv2
 import (
 	"context"
 	"fmt"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/influxdbv2/resource_create_authorization.go
+++ b/influxdbv2/resource_create_authorization.go
@@ -104,7 +104,7 @@ func resourceAuthorizationCreate(d *schema.ResourceData, meta interface{}) error
 	d.SetId(*result.Id)
 	// token is only ever received once, so we must set it from this response
 	// and can not read it later
-	err = d.Set("token", result.Token)
+	err = d.Set("token", *result.Token)
 	if err != nil {
 		return err
 	}

--- a/influxdbv2/resource_create_authorization.go
+++ b/influxdbv2/resource_create_authorization.go
@@ -104,7 +104,7 @@ func resourceAuthorizationCreate(d *schema.ResourceData, meta interface{}) error
 	d.SetId(*result.Id)
 	// token is only ever received once, so we must set it from this response
 	// and can not read it later
-	err = d.Set("token", authorizations.Token)
+	err = d.Set("token", result.Token)
 	if err != nil {
 		return err
 	}

--- a/influxdbv2/resource_create_authorization.go
+++ b/influxdbv2/resource_create_authorization.go
@@ -3,7 +3,6 @@ package influxdbv2
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	influxdb2 "github.com/influxdata/influxdb-client-go/v2"
@@ -144,7 +143,7 @@ func resourceAuthorizationRead(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return err
 	}
-	if strings.Compare(*authorizations.Token, "redacted") != 0 {
+	if *authorizations.Token != "redacted" {
 		err = d.Set("token", authorizations.Token)
 		if err != nil {
 			return err

--- a/main.go
+++ b/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
-	"github.com/janrupf/terraform-provider-influxdb-v2/influxdbv2"
+	"github.com/optile/terraform-provider-influxdb-v2/influxdbv2"
 )
 
 // Generate the Terraform provider documentation using `tfplugindocs`:

--- a/scripts/setup_influxdb.sh
+++ b/scripts/setup_influxdb.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/.env bash
+#!/usr/bin/env bash
 
 echo "1) launching influx"
 docker run -d --name tf_acc_tests_influxdb -p 8086:8086 influxdb:2.0.7


### PR DESCRIPTION
We need to read the token from the initial response, it is only available once.

Read and set the token from the initial response, then ignore any further changes if the token content is `redacted`